### PR TITLE
Fix: rotate particle system rather than the camera

### DIFF
--- a/src/app/three/index.ts
+++ b/src/app/three/index.ts
@@ -56,17 +56,19 @@ export function createBg() {
 
   // Controls
   const controls = new OrbitControls(camera, renderer.domElement);
+  controls.addEventListener('change', function() { renderer.render(scene, camera); });
   controls.enableDamping = true;
+  controls.enableZoom = false;
+  controls.enablePan = false;
 
   // Animation
   const animate = () => {
     controls.update();
 
-    const time = Date.now() * 0.00005;
-    const radius = 5;
-    camera.position.x = radius * Math.cos(time);
-    camera.position.z = radius * Math.sin(time);
-    camera.lookAt(scene.position);
+    particlesGeometry.rotateX(0.001);
+    particlesGeometry.rotateY(0.001);
+    particlesGeometry.rotateZ(0.001);
+    particlesGeometry.needsUpdate = true;
 
     renderer.render(scene, camera);
     requestAnimationFrame(animate);


### PR DESCRIPTION
Previous behaviour allows the user to scroll or zoom out of the frame revealing the "skybox" with the stars in it. Disabling the zoom and pan functionality are not enough on it's own, since our animation modifies the camera[1]. If instead, we rotate the particle system around the camera, we can disable those interactions.

One additional benefit, it is now possible to create more complex paths for the particles since we are now free to translate or rotate the individual points. It shouldn't take more cycles since WebGL should give this to the GPU which can calculate things like this easily.

Also, but this is vibe-based opinion, typically it is nicer to move the world than the camera. Moving the camera can complicate matters if you would like to add more objects since you'd need to counteract the skybox camera movement in their positions.


[1] No idea why this matters, but apparently it does.
